### PR TITLE
fix unsupported %z format flag, add some windows compat switches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .*
 *~
 *.o
+*.lo
 /test
 /selftest

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BIN = selftest test
 
 all: $(BIN)
 
-utcp.o: utcp.c compat.h utcp.h utcp_priv.h
+utcp.o: utcp.c
 
 test: utcp.o test.c
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BIN = selftest test
 
 all: $(BIN)
 
-utcp.o: utcp.c
+utcp.o: utcp.c utcp.h utcp_priv.h compat.h
 
 test: utcp.o test.c
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BIN = selftest test
 
 all: $(BIN)
 
-utcp.o: utcp.c utcp.h utcp_priv.h
+utcp.o: utcp.c compat.h utcp.h utcp_priv.h
 
 test: utcp.o test.c
 

--- a/compat.h
+++ b/compat.h
@@ -11,7 +11,7 @@
   #include <sys/time.h>
 #endif
 
-#if !defined(PRINT_SIZE_T)
+#ifndef PRINT_SIZE_T
   #ifdef _WIN32
     #define PRINT_SIZE_T "%Iu"
     #define PRINT_SSIZE_T "%Id"

--- a/compat.h
+++ b/compat.h
@@ -8,7 +8,9 @@
 #ifdef _WIN32
   #include <winsock2.h>
 #else
+  #include <unistd.h>
   #include <sys/time.h>
+  #include <sys/socket.h>
 #endif
 
 #ifndef PRINT_SIZE_T

--- a/compat.h
+++ b/compat.h
@@ -23,9 +23,14 @@
 
 #ifdef _MSC_VER
   // VS2012 and up has no ssize_t defined, before it was defined as unsigned int
-  #ifndef _SSIZE_T
-    #define _SSIZE_T
-    typedef signed int        ssize_t;
+  #ifndef _SSIZE_T_DEFINED
+    #define _SSIZE_T_DEFINED
+    #undef ssize_t
+    #ifdef _WIN64
+      typedef signed __int64  ssize_t;
+    #else
+      typedef signed int      ssize_t;
+    #endif
   #endif
 #endif
 

--- a/compat.h
+++ b/compat.h
@@ -1,0 +1,32 @@
+#ifndef UTCP_COMPAT_H
+#define UTCP_COMPAT_H
+
+#ifndef _MSC_VER
+  #include <unistd.h>
+#endif
+
+#ifdef _WIN32
+  #include <winsock2.h>
+#else
+  #include <sys/time.h>
+#endif
+
+#if !defined(PRINT_SIZE_T)
+  #ifdef _WIN32
+    #define PRINT_SIZE_T "%Iu"
+    #define PRINT_SSIZE_T "%Id"
+  #else
+    #define PRINT_SIZE_T "%zu"
+    #define PRINT_SSIZE_T "%zd"
+  #endif
+#endif
+
+#ifdef _MSC_VER
+  // VS2012 and up has no ssize_t defined, before it was defined as unsigned int
+  #ifndef _SSIZE_T
+    #define _SSIZE_T
+    typedef signed int        ssize_t;
+  #endif
+#endif
+
+#endif // UTCP_COMPAT_H

--- a/selftest.c
+++ b/selftest.c
@@ -85,7 +85,7 @@ int main(int argc, char *argv[]) {
 		if(len < 0)
 			fprintf(stderr, "Error: %s\n", strerror(errno));
 		else
-			fprintf(stderr, "Short write %zd!\n", len);
+			fprintf(stderr, "Short write " PRINT_SSIZE_T "!\n", len);
 	}
 	len = utcp_send(c, "This is a test.\n", 16);
 
@@ -93,7 +93,7 @@ int main(int argc, char *argv[]) {
 		if(len < 0)
 			fprintf(stderr, "Error: %s\n", strerror(errno));
 		else
-			fprintf(stderr, "Short write %zd!\n", len);
+			fprintf(stderr, "Short write " PRINT_SSIZE_T "!\n", len);
 	}
 
 	fprintf(stderr, "closing...\n");
@@ -107,7 +107,7 @@ int main(int argc, char *argv[]) {
 
 	len = utcp_send(c, buf, sizeof buf);
 	if(len != 10240)
-		fprintf(stderr, "Error: utcp_send() returned %zd, expected 10240\n", len);
+		fprintf(stderr, "Error: utcp_send() returned " PRINT_SSIZE_T ", expected 10240\n", len);
 
 	fprintf(stderr, "closing...\n");
 	utcp_close(c);

--- a/test.c
+++ b/test.c
@@ -132,7 +132,7 @@ int main(int argc, char *argv[]) {
 			if(c) {
 				ssize_t sent = utcp_send(c, buf, len);
 				if(sent != len)
-					fprintf(stderr, "PANIEK: %zd != %zd\n", sent, len);
+					fprintf(stderr, "PANIEK: " PRINT_SSIZE_T " != " PRINT_SSIZE_T "\n", sent, len);
 			}
 		}
 

--- a/test.c
+++ b/test.c
@@ -6,7 +6,6 @@
 #include <time.h>
 #include <errno.h>
 #include <sys/types.h>
-#include <sys/socket.h>
 #include <netdb.h>
 #include <poll.h>
 

--- a/utcp.c
+++ b/utcp.c
@@ -26,9 +26,14 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <string.h>
+
+#ifdef _WIN32
+#include <winsock2.h>
+#else
 #include <unistd.h>
 #include <sys/time.h>
 #include <sys/socket.h>
+#endif
 
 #include "utcp_priv.h"
 
@@ -66,12 +71,12 @@ static void debug(const char *format, ...) {
 static void print_packet(struct utcp *utcp, const char *dir, const void *pkt, size_t len) {
 	struct hdr hdr;
 	if(len < sizeof hdr) {
-		debug("%p %s: short packet (%zu bytes)\n", utcp, dir, len);
+		debug("%p %s: short packet (" PRINT_SIZE_T " bytes)\n", utcp, dir, len);
 		return;
 	}
 
 	memcpy(&hdr, pkt, sizeof hdr);
-	fprintf (stderr, "%p %s: len=%zu, src=%u dst=%u seq=%u ack=%u wnd=%u ctl=", utcp, dir, len, hdr.src, hdr.dst, hdr.seq, hdr.ack, hdr.wnd);
+	fprintf (stderr, "%p %s: len=" PRINT_SIZE_T ", src=%u dst=%u seq=%u ack=%u wnd=%u ctl=", utcp, dir, len, hdr.src, hdr.dst, hdr.seq, hdr.ack, hdr.wnd);
 	if(hdr.ctl & SYN)
 		debug("SYN");
 	if(hdr.ctl & RST)
@@ -671,7 +676,7 @@ ssize_t utcp_recv(struct utcp *utcp, const void *data, size_t len) {
 #endif
 
 	if(!acceptable) {
-		debug("Packet not acceptable, %u <= %u + %zu < %u\n", c->rcv.nxt, hdr.seq, len, c->rcv.nxt + c->rcv.wnd);
+		debug("Packet not acceptable, %u <= %u + " PRINT_SIZE_T " < %u\n", c->rcv.nxt, hdr.seq, len, c->rcv.nxt + c->rcv.wnd);
 		// Ignore unacceptable RST packets.
 		if(hdr.ctl & RST)
 			return 0;

--- a/utcp.c
+++ b/utcp.c
@@ -27,12 +27,6 @@
 #include <stdbool.h>
 #include <string.h>
 
-#ifndef _WIN32
-#include <unistd.h>
-#include <sys/time.h>
-#include <sys/socket.h>
-#endif
-
 #include "utcp_priv.h"
 
 #ifndef EBADMSG

--- a/utcp.c
+++ b/utcp.c
@@ -27,9 +27,7 @@
 #include <stdbool.h>
 #include <string.h>
 
-#ifdef _WIN32
-#include <winsock2.h>
-#else
+#ifndef _WIN32
 #include <unistd.h>
 #include <sys/time.h>
 #include <sys/socket.h>

--- a/utcp.h
+++ b/utcp.h
@@ -20,11 +20,11 @@
 #ifndef UTCP_H
 #define UTCP_H
 
-#include <unistd.h>
 #include <stdint.h>
 #include <stdbool.h>
+
 // TODO: Windows
-#include <sys/time.h>
+#include "compat.h"
 
 #ifndef UTCP_INTERNAL
 struct utcp {

--- a/utcp.h
+++ b/utcp.h
@@ -23,7 +23,6 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-// TODO: Windows
 #include "compat.h"
 
 #ifndef UTCP_INTERNAL


### PR DESCRIPTION
compat switches copied from meshlink library
mingw depends on the windows c library which has no full c99 support yet

sadly the compiler doesn't warn on unsupported %z usage:
`Other library implementations may not support all these features; GCC does not support warning about features that go beyond a particular library's limitations.`
https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html

on windows for %zu simply 'zu' is printed, and onfollowing variable specifiers mess up with the variable list resulting in a SIGSEGV
