### PR TITLE
Feature/fix finack

### DIFF
--- a/utcp.c
+++ b/utcp.c
@@ -1059,7 +1059,7 @@ ssize_t utcp_recv(struct utcp *utcp, const void *data, size_t len) {
 			// accept overlapping packets
 			else if(rcv_offset < 0) {
 				// cut already accepted front overlapping
-				if(len > -rcv_offset) {
+				if(len >= -rcv_offset) {
 					data -= rcv_offset;
 					len += rcv_offset;
 					acceptable = true;


### PR DESCRIPTION
this properly should fix the previous issue of sending acks on packets that are cut to 0 datalen
plus fix hdr.seq + len on overlapping packets as hdr.seq wasn't increased along with the len cut
