### PR TITLE
fix partial packets & seq no & both way send triple ack

### DIFF
--- a/README
+++ b/README
@@ -216,8 +216,9 @@ RECEIVE PACKET
   b SYN state changes
   c new data state changes
   d FIN state changes
-5 Ack accepted packets
-6 Send new data to application
+5 Consume incoming packet data
+6 Ack accepted packets
+7 Send new data to application
 
 CONGESTION AVOIDANCE
 --------------------

--- a/utcp.c
+++ b/utcp.c
@@ -119,6 +119,8 @@ static void print_packet(struct utcp *utcp, const char *dir, const void *pkt, si
         debug("FIN");
     if(hdr.ctl & ACK)
         debug("ACK");
+    if(hdr.ctl & RTR)
+        debug("RTR");
 
     if(len > sizeof hdr) {
         uint32_t datalen = len - sizeof hdr;

--- a/utcp.c
+++ b/utcp.c
@@ -1651,7 +1651,9 @@ ssize_t utcp_recv(struct utcp *utcp, const void *data, size_t len) {
     // 6. Ack accepted packets
 
     // Now we send something back if:
-    // - we advanced rcv.nxt (ie, we got some data that needs to be ACKed)
+    // - we received data to process
+    //   -> sendatleastone = true, with RTR flag set for the Triplicate ACK if ahead
+    // - rcv.nxt is changed (ie, we got a SYNACK)
     //   -> sendatleastone = true
     // - or we got an ack, so we should maybe send a bit more data
     //   -> sendatleastone = false

--- a/utcp.c
+++ b/utcp.c
@@ -1626,7 +1626,7 @@ ssize_t utcp_recv(struct utcp *utcp, const void *data, size_t len) {
         closed = true;
     }
 
-    // 5. Ack accepted packets
+    // 5. Consume incoming packet data, advancing the rcv.nxt counter
     char* frombuf = NULL;
     if(handle_incoming && rcv_offset <= 0)
     {
@@ -1648,6 +1648,8 @@ ssize_t utcp_recv(struct utcp *utcp, const void *data, size_t len) {
         c->rcv.nxt += len;
     }
 
+    // 6. Ack accepted packets
+
     // Now we send something back if:
     // - we advanced rcv.nxt (ie, we got some data that needs to be ACKed)
     //   -> sendatleastone = true
@@ -1655,7 +1657,7 @@ ssize_t utcp_recv(struct utcp *utcp, const void *data, size_t len) {
     //   -> sendatleastone = false
     ack(c, len || prevrcvnxt != c->rcv.nxt);
 
-    // 6. Send new data to application
+    // 7. Send new data to application
     // Given the ack is used for roundtrip measurement and a too high response time or variation
     // easily implicts retransmits, delay all compution intensive processing till after the ack.
 

--- a/utcp.c
+++ b/utcp.c
@@ -1005,14 +1005,14 @@ static void sack_consume(struct utcp_connection *c, size_t len) {
         debug("SACK[%d] offset %u len %u\n", i, c->sacks[i].offset, c->sacks[i].len);
 }
 
-static size_t buffer_consumable(struct utcp_connection *c, size_t buffer_start) {
+static size_t buffer_consumable(struct utcp_connection *c, size_t bufferOffset) {
     // Check if we can process out-of-order data now.
-    if(c->sacks[0].len && offset >= c->sacks[0].offset) {
+    if(c->sacks[0].len && bufferOffset >= c->sacks[0].offset) {
         // compute consumable end size
-        size_t consumable = buffer_start;
+        size_t consumable = bufferOffset;
         for(int i = 0; i < NSACKS && c->sacks[i].len && c->sacks[i].offset <= consumable; i++)
             consumable = max(consumable, c->sacks[i].offset + c->sacks[i].len);
-        return consumable - buffer_start;
+        return consumable - bufferOffset;
     }
     return 0;
 }

--- a/utcp.c
+++ b/utcp.c
@@ -1337,7 +1337,7 @@ ssize_t utcp_recv(struct utcp *utcp, const void *data, size_t len) {
             if(data_acked && c->ack)
                 c->ack(c, data_acked);
         }
-        else if(!progress && !len && pkt->hdr.ctl & RTR) {
+        else if(!progress && pkt->hdr.ctl & RTR) {
             // Count duplicate acks but disregard those for packets that were behind
             // Only for triplicate acks that signal missing data perform the retransmit
             c->dupack++;

--- a/utcp.c
+++ b/utcp.c
@@ -1645,7 +1645,7 @@ ssize_t utcp_recv(struct utcp *utcp, const void *data, size_t len) {
             sack_consume(c, data_len);
 
         // advance ack sequence number for the next packet to receive
-        c->rcv.nxt += len;
+        c->rcv.nxt += data_len;
     }
 
     // 6. Ack accepted packets


### PR DESCRIPTION
fixes everbase/backend/#1797

* partial packts with rcv_offset < 0 previously were detected out_of_order and dropped
* the ack sequence number didn't advance since it was acked ahead of processing the data
* triplicate acks likely were missed when there's been data sent both ways due to a redundant packet len check, while the RTR flag already tells enough